### PR TITLE
augment script to add custom pageview prop #121

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <script defer data-domain="chichives.com" src="https://plausible.io/js/script.js"></script>
+    <script defer onload="plausible('pageview', {props: {language: navigator.language || navigator.userLanguage}})" data-domain="chichives.com" src="https://plausible.io/js/script.manual.js"></script>
     <link rel="icon" href="%PUBLIC_URL%/icons/favicon-transparent.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
Initial implementation of custom language property in plausible analytics.

Use `onload` so that the subsequent invokation of `plausible()` doesn't fail if an ad blocker has blocked the script load. Also allows for the use of `defer`.