### PR TITLE
#123: Add Google Translation Widget to Chieve Site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>ChiVes</title>
+    <title translate="no">ChiVes</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -36,9 +36,11 @@ const googleTranslateElementInit = () => {
 const useStyles = makeStyles((theme) => ({
 	googleTranslateElement: {
 		position: "fixed",
-		bottom: "10px",
-		left: "10px",
+		bottom: "4em",
+		left: "0.5em", //same left margin as the Nav Menu
 		zIndex: "1000",
+    backgroundColor: "rgba(255,255,255,0.75)",
+    padding: "15px" //same padding as the Nav Menu
 	},
 }));
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
-import React, { Suspense  } from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-
-import {Home, LoadingMessage, ErrorPage} from './components/';
-import { ThemeProvider, StyledEngineProvider, createTheme } from '@mui/material/styles';
-
-// import makeStyles from '@mui/styles/makeStyles';
+import React, { Suspense } from "react";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Home, LoadingMessage, ErrorPage } from "./components/";
+import {
+	ThemeProvider,
+	StyledEngineProvider,
+	createTheme,
+} from "@mui/material/styles";
+import makeStyles from "@mui/styles/makeStyles";
 
 const theme = createTheme();
 
@@ -14,42 +16,84 @@ const theme = createTheme();
 //   }
 // });
 
-const Map = React.lazy(() => import('./components/Pages/Map'));
-const About = React.lazy(() => import('./components/Pages/About'));
-const Guide = React.lazy(() => import('./components/Pages/Guide'));
-const Contact = React.lazy(() => import('./components/Pages/Contact'));
-const Community = React.lazy(() => import('./components/Pages/Community'));
-const Data = React.lazy(() => import('./components/Pages/Data'));
+const Map = React.lazy(() => import("./components/Pages/Map"));
+const About = React.lazy(() => import("./components/Pages/About"));
+const Guide = React.lazy(() => import("./components/Pages/Guide"));
+const Contact = React.lazy(() => import("./components/Pages/Contact"));
+const Community = React.lazy(() => import("./components/Pages/Community"));
+const Data = React.lazy(() => import("./components/Pages/Data"));
+
+/** Google Translation Widget */
+const googleTranslateElementInit = () => {
+	new window.google.translate.TranslateElement(
+		{
+			pageLanguage: "en",
+			autoDisplay: false,
+		},
+		"google_translate_element"
+	);
+};
+const useStyles = makeStyles((theme) => ({
+	googleTranslateElement: {
+		position: "fixed",
+		bottom: "10px",
+		left: "10px",
+		zIndex: "1000",
+	},
+}));
 
 export default function App() {
+	const googleTranslateElement = useStyles();
+	React.useEffect(() => {
+		var addScript = document.createElement("script");
+		addScript.setAttribute(
+			"src",
+			"//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+		);
+		document.body.appendChild(addScript);
+		window.googleTranslateElementInit = googleTranslateElementInit;
+	}, []);
 
-    return (
-      <Router basename={process.env.PUBLIC_URL}>
-      <div>
-      <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={theme}>
-          <Suspense fallback={<LoadingMessage />}>
-              <Switch>
-                <Route path="/" component={Home} exact/>
-                <Route path="/map" component={Map}/>
-                <Route path="/map.html" component={Map}/>
-                <Route path="/about" component={About}/>
-                <Route path="/about.html" component={About}/>
-                <Route path="/guide" component={Guide}/>
-                <Route path="/guide.html" component={Guide}/>
-                <Route path="/contact" component={Contact}/>
-                <Route path="/contact.html" component={Contact}/>
-                <Route path="/community" component={Community}/>
-                <Route path="/community.html" component={Community}/>              
-                <Route path="/data" component={Data}/>
-                <Route path="/data.html" component={Data}/>
-                <Route component={ErrorPage} />
-                <Route />
-            </Switch>
-          </Suspense>
-          </ThemeProvider>
-      </StyledEngineProvider>
-      </div> 
-    </Router>
-    );
+	return (
+		<Router basename={process.env.PUBLIC_URL}>
+			<div>
+				<div
+					id="google_translate_element"
+					className={googleTranslateElement.googleTranslateElement}
+				></div>
+				<StyledEngineProvider injectFirst>
+					<ThemeProvider theme={theme}>
+						<Suspense fallback={<LoadingMessage />}>
+							<Switch>
+								<Route path="/" component={Home} exact />
+								<Route path="/map" component={Map} />
+								<Route path="/map.html" component={Map} />
+								<Route path="/about" component={About} />
+								<Route path="/about.html" component={About} />
+								<Route path="/guide" component={Guide} />
+								<Route path="/guide.html" component={Guide} />
+								<Route path="/contact" component={Contact} />
+								<Route
+									path="/contact.html"
+									component={Contact}
+								/>
+								<Route
+									path="/community"
+									component={Community}
+								/>
+								<Route
+									path="/community.html"
+									component={Community}
+								/>
+								<Route path="/data" component={Data} />
+								<Route path="/data.html" component={Data} />
+								<Route component={ErrorPage} />
+								<Route />
+							</Switch>
+						</Suspense>
+					</ThemeProvider>
+				</StyledEngineProvider>
+			</div>
+		</Router>
+	);
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Route, Switch, useLocation } from "react-router-dom";
 import { Home, LoadingMessage, ErrorPage } from "./components/";
 import {
 	ThemeProvider,
@@ -36,16 +36,15 @@ const googleTranslateElementInit = () => {
 const useStyles = makeStyles((theme) => ({
 	googleTranslateElement: {
 		position: "fixed",
-		bottom: "4em",
 		left: "0.5em", //same left margin as the Nav Menu
 		zIndex: "1000",
-    backgroundColor: "rgba(255,255,255,0.75)",
-    padding: "15px" //same padding as the Nav Menu
+		backgroundColor: "rgba(255,255,255,0.75)",
+		padding: "15px", //same padding as the Nav Menu
 	},
 }));
 
 export default function App() {
-	const googleTranslateElement = useStyles();
+	const classes = useStyles();
 	React.useEffect(() => {
 		var addScript = document.createElement("script");
 		addScript.setAttribute(
@@ -57,45 +56,42 @@ export default function App() {
 	}, []);
 
 	return (
-		<Router basename={process.env.PUBLIC_URL}>
-			<div>
-				<div
-					id="google_translate_element"
-					className={googleTranslateElement.googleTranslateElement}
-				></div>
-				<StyledEngineProvider injectFirst>
-					<ThemeProvider theme={theme}>
-						<Suspense fallback={<LoadingMessage />}>
-							<Switch>
-								<Route path="/" component={Home} exact />
-								<Route path="/map" component={Map} />
-								<Route path="/map.html" component={Map} />
-								<Route path="/about" component={About} />
-								<Route path="/about.html" component={About} />
-								<Route path="/guide" component={Guide} />
-								<Route path="/guide.html" component={Guide} />
-								<Route path="/contact" component={Contact} />
-								<Route
-									path="/contact.html"
-									component={Contact}
-								/>
-								<Route
-									path="/community"
-									component={Community}
-								/>
-								<Route
-									path="/community.html"
-									component={Community}
-								/>
-								<Route path="/data" component={Data} />
-								<Route path="/data.html" component={Data} />
-								<Route component={ErrorPage} />
-								<Route />
-							</Switch>
-						</Suspense>
-					</ThemeProvider>
-				</StyledEngineProvider>
-			</div>
-		</Router>
+		<div>
+			<div
+				id="google_translate_element"
+				className={classes.googleTranslateElement}
+				style={
+					useLocation().pathname.indexOf("map") > -1
+						? { bottom: "4em" } //if on map page, move up to avoid overlapping with map controls
+						: { bottom: "0.5em" }
+				}
+			></div>
+			<StyledEngineProvider injectFirst>
+				<ThemeProvider theme={theme}>
+					<Suspense fallback={<LoadingMessage />}>
+						<Switch>
+							<Route path="/" component={Home} exact />
+							<Route path="/map" component={Map} />
+							<Route path="/map.html" component={Map} />
+							<Route path="/about" component={About} />
+							<Route path="/about.html" component={About} />
+							<Route path="/guide" component={Guide} />
+							<Route path="/guide.html" component={Guide} />
+							<Route path="/contact" component={Contact} />
+							<Route path="/contact.html" component={Contact} />
+							<Route path="/community" component={Community} />
+							<Route
+								path="/community.html"
+								component={Community}
+							/>
+							<Route path="/data" component={Data} />
+							<Route path="/data.html" component={Data} />
+							<Route component={ErrorPage} />
+							<Route />
+						</Switch>
+					</Suspense>
+				</ThemeProvider>
+			</StyledEngineProvider>
+		</div>
 	);
 }

--- a/src/components/Layout/ContactForm.js
+++ b/src/components/Layout/ContactForm.js
@@ -143,7 +143,7 @@ export default function ContactForm(){
         {submitted && 
             <SuccessMessage>
                 <p>
-                    Thanks for your message! Our team will review your message and get back with you as soon as possible. We value your feedback and engagement as we work to improve the ChiVes explorer!
+                    Thanks for your message! Our team will review your message and get back with you as soon as possible. We value your feedback and engagement as we work to improve the<span translate="no"> ChiVes </span>explorer!
                 </p>
                 <button onClick={() => setSubmitted(false)}>×</button>
             </SuccessMessage>

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -101,7 +101,7 @@ const Footer = (props) => {
       <FooterContent>
         <LinkLists container spacing={0}>
           <Grid item xs={12}>
-            <h6>ChiVes</h6>
+            <h6 translate="no">ChiVes</h6>
           </Grid>
           <Grid item xs={12} md={6}>
             <Grid container spacing={0}>
@@ -156,7 +156,7 @@ const Footer = (props) => {
           </Grid>
           <Grid item xs={12}>
             <p className="copyright" style={{marginTop: "20px"}}>
-              Copyright ChiVes Contributors, Healthy Regions & Policies Lab
+              Copyright<span translate="no"> ChiVes </span>Contributors, Healthy Regions & Policies Lab
               <br />
               Website Licensed GPL, Data Licensed CC NC Attribution
             </p>

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -167,7 +167,7 @@ export default function Nav({
     <NavContainer>
       <LogoButtonContainer aria-describedby={id} variant="outlined" onClick={handleClick} title={id} color="success">
         <SvgLogo colors={[colors.green, colors.chicagoBlue, colors.skyblue, colors.chicagoDarkBlue, colors.chicagoRed]}></SvgLogo>
-        <Typography><span style={{fontWeight:"bold", color:"#2e7d32"}}> ChiVes</span></Typography>
+        <Typography><span style={{fontWeight:"bold", color:"#2e7d32"}} translate="no"> ChiVes</span></Typography>
         {SVG.hamburger}
       </LogoButtonContainer>
       <Popover

--- a/src/components/Pages/About.js
+++ b/src/components/Pages/About.js
@@ -239,7 +239,7 @@ const accordionContent = [
         {
         label: "Chicago Tree Tool (2022)",
         content: (<p>
-                    Before <i>ChiVes</i>, HeRoP worked in joint partnership with the Chicago Department of Public Health to develop the <b> <a href="https://abc7chicago.com/chicago-trees-climate-change-tree-planting-lidar-scanner/11202738/?fbclid=IwAR0UxJhaeu_vMfES7H0owokO4y2ASs3uzZAGCYrWzfMpwS4rUiAB7kULLi0">Community Tree Equity Tool </a></b> as 
+                    Before <i translate="no">ChiVes</i>, HeRoP worked in joint partnership with the Chicago Department of Public Health to develop the <b> <a href="https://abc7chicago.com/chicago-trees-climate-change-tree-planting-lidar-scanner/11202738/?fbclid=IwAR0UxJhaeu_vMfES7H0owokO4y2ASs3uzZAGCYrWzfMpwS4rUiAB7kULLi0">Community Tree Equity Tool </a></b> as 
                     an extension of  ongoing work on understanding <a href="https://healthyregions.org/research/open-airq/" target="_blank" rel="noopener noreferrer">air quality in Chicago</a>. The Tree Tool Research Pilot was developed using 
                      <a href="https://carto.com/" target="_blank" rel="noopener noreferrer"> Carto</a> to facilitate rapid development and prototyping. This tool followed years of iterative process and design and dozens
                      of previous dashboard iterations, highlighting the winding process of agile application development. The final tool went through dozens of additional
@@ -270,13 +270,13 @@ export default function About(){
 
                <p>
 
-               ChiVes is a <b>data collaborative</b> and <b>community mapping application</b> that brings data on Chicago’s environment together at the neighborhood level. It is a partnership of researchers, community organizations, and civic groups. 
-                Organizations and individuals can participate in ChiVes in multiple ways:
+              <span translate="no"> ChiVes </span>is a <b>data collaborative</b> and <b>community mapping application</b> that brings data on Chicago’s environment together at the neighborhood level. It is a partnership of researchers, community organizations, and civic groups. 
+                Organizations and individuals can participate in<span translate="no"> ChiVes </span>in multiple ways:
 
                 <br/><br/>
                 <li> <a href="https://docs.google.com/forms/d/e/1FAIpQLSdu5zCJcvLXp8eY0p3jLuCWPKSuGHjrw2auO3BsD57ssH4_wA/viewform">Data Collaborative.</a> Integrate your data directly. Members agree that the final, integrated data will meet Collaborative standards. </li>
-                <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSd2gHSB7OKCKEBhB0weIM7ZsRBomVOAl7QhDHOeXu5B7ih_bQ/viewform">Resource Guide.</a> Share your web-based or print media resource on the Chicago environment. Resources must meet ChiVes standards. </li>
-                <li><a href="https://github.com/GeoDaCenter/chicago-environment-explorer">Web Development.</a> Developers and code-enthusiasts can fork the ChiVes website, make changes, and submit for review.</li>
+                <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSd2gHSB7OKCKEBhB0weIM7ZsRBomVOAl7QhDHOeXu5B7ih_bQ/viewform">Resource Guide.</a> Share your web-based or print media resource on the Chicago environment. Resources must meet<span translate="no"> ChiVes </span>standards. </li>
+                <li><a href="https://github.com/GeoDaCenter/chicago-environment-explorer">Web Development.</a> Developers and code-enthusiasts can fork the<span translate="no"> ChiVes </span>website, make changes, and submit for review.</li>
                  
                 <br/>
                 View our <a href="https://docs.google.com/document/d/12lwkCAXxI9eW4Mdf6gaeR6LCsaNI3E0E6xvi7dqXr9k/edit?usp=sharing">Standards and Submission Guidelines</a>. These guidelines are evaluated on a regular basis by members of the Data Collaborative.  
@@ -289,7 +289,7 @@ export default function About(){
                     <h3>Data Contributions </h3>
 
                     <p> 
-                    The following individuals and organizations have added data to the ChiVes collective:
+                    The following individuals and organizations have added data to the<span translate="no"> ChiVes </span>collective:
                     <li> <a href="https://www.chicagobotanic.org/research/staff/anderson">Elsa Anderson</a> & <a href="https://www.chicagobotanic.org/research/staff/taddeo">Sophie Taddeo</a>, Negaunee Institute for Plant Conservation Science and Action, Chicago Botanic Gardens </li>
                     <li> <a href="http://www.madeleinedaepp.com/">Madeleine Daepp</a>, Microsoft Research & the Eclipse Project </li>
                     <li> <a href="https://sites.northwestern.edu/danethan/anastasia-montgomery-bio/">Anastasia (Stacy) Montgomery</a>, <a href="https://www.earth.northwestern.edu/our-people/post-doctoral-fellows/sara-camilleri.html">Sara Camilleri</a> & <a href="https://www.earth.northwestern.edu/our-people/faculty/horton-daniel.html">Dan Horton</a>, Climate Change Research Group, Northwestern University </li>
@@ -299,7 +299,7 @@ export default function About(){
 
                     
                     <h3>Data & Design Decision-Making </h3>
-                    In addition to data contributions above, collaborative members have also provided invaluable insight and direction throughout the project. Data Collective members have advised on ChiVes data standards and needs, 
+                    In addition to data contributions above, collaborative members have also provided invaluable insight and direction throughout the project. Data Collective members have advised on<span translate="no"> ChiVes </span>data standards and needs, 
                     as well as provided feedback on visualization and user experience goals. 
                     <br></br>
                     <br></br>
@@ -326,10 +326,10 @@ export default function About(){
                    Core Project Team
                 </h2>
     
-                <p>This project is brought to you by the <a href="https://healthyregions.org/" target="_blank">Healthy Regions & Policies Lab</a> (HeRoP), housed at the Department of Geography & GIScience within the <b>University of Illinois at Urbana-Champaign</b>, in collaboration with the <a href="https://las.depaul.edu/academics/geography-gis/Pages/default.aspx" target="_blank">Department of Geography</a> at <b>DePaul University</b>. The original ChiVes emerged from HeRoP while at the Center for Spatial Data Science within the University of Chicago. 
+                <p>This project is brought to you by the <a href="https://healthyregions.org/" target="_blank">Healthy Regions & Policies Lab</a> (HeRoP), housed at the Department of Geography & GIScience within the <b>University of Illinois at Urbana-Champaign</b>, in collaboration with the <a href="https://las.depaul.edu/academics/geography-gis/Pages/default.aspx" target="_blank">Department of Geography</a> at <b>DePaul University</b>. The original<span translate="no"> ChiVes </span>emerged from HeRoP while at the Center for Spatial Data Science within the University of Chicago. 
                   <br/><br/>
 
-                ChiVes is funded in part by <b>NASA</b> with a new initiative starting in 2022 led by Drs. Stuhlmacher, Curran, and Kolak (read more <a href="https://depauliaonline.com/64087/special-issues/research-team-seeks-to-expand-access-to-environmental-data-in-chicago-nasa-grant-provides-funding-for-research-expansion-of-chives-database/">here</a> and 
+               <span translate="no"> ChiVes </span>is funded in part by <b>NASA</b> with a new initiative starting in 2022 led by Drs. Stuhlmacher, Curran, and Kolak (read more <a href="https://depauliaonline.com/64087/special-issues/research-team-seeks-to-expand-access-to-environmental-data-in-chicago-nasa-grant-provides-funding-for-research-expansion-of-chives-database/">here</a> and 
                 <a href="https://ggis.illinois.edu/news/2022-09-19t152513/prof-kolak-depaul-researchers-receive-nasa-grant-data-driven-environmental"> here</a>).
 
                 </p>
@@ -364,7 +364,7 @@ export default function About(){
                 <h2> 
                    Background  
                 </h2>
-                <p> The original ChiVes application built on multiple former projects from Healthy Regions & Policies Lab members, incorporating materials as well as lessons learned. Much of the data currently integrated within ChiVes was gathered, calculated, and standardized from 2018-2021. The current application was refactored in 2022 by <a href="https://dylanhalpern.com/">Dylan Halpern</a>, adopting a new web architecture. Explore some of the original projects that inspired ChiVes below:  </p>
+                <p> The original<span translate="no"> ChiVes </span>application built on multiple former projects from Healthy Regions & Policies Lab members, incorporating materials as well as lessons learned. Much of the data currently integrated within<span translate="no"> ChiVes </span>was gathered, calculated, and standardized from 2018-2021. The current application was refactored in 2022 by <a href="https://dylanhalpern.com/">Dylan Halpern</a>, adopting a new web architecture. Explore some of the original projects that inspired<span translate="no"> ChiVes </span>below:  </p>
                 <br/>
 
                 <Accordion entries={accordionContent} initialTab={-1} />

--- a/src/components/Pages/Community.js
+++ b/src/components/Pages/Community.js
@@ -620,7 +620,7 @@ function App() {
       <ContentContainer>
         <h1>Community</h1>
         <p>
-          ChiVes community reports provide information and context about your
+         <span translate="no"> ChiVes </span>community reports provide information and context about your
           community, zip code, or census tract. To start, search for your
           location or use your current location.
         </p>

--- a/src/components/Pages/Contact.js
+++ b/src/components/Pages/Contact.js
@@ -47,7 +47,7 @@ export default function Contact(){
                 </a>
                 <hr/>
                 <p>
-                    Contact the <i>ChiVes</i> leadership team directly through this form if you have any questions about the project or media inquiries.
+                    Contact the <i translate="no">ChiVes</i> leadership team directly through this form if you have any questions about the project or media inquiries.
                 </p>
                 
                 <ContactForm />

--- a/src/components/Pages/Data.js
+++ b/src/components/Pages/Data.js
@@ -74,7 +74,7 @@ const NewTabLink = ({ link, text }) => <a href={link} target="_blank" rel="noope
 const columns = [
     {
         Header: 'Variable',
-        accessor: 'Variable Name',
+        accessor: f => <span translate="no">{f['Variable Name']}</span>,
     },
     {
         Header: "Contributor",
@@ -155,7 +155,7 @@ export default function Data() {
                         return (
                         <li key={i}>
                             <p>
-                            <b>{Column}:</b> {Description}
+                            <b translate="no">{Column}:</b> {Description}
                             </p>
                         </li>
                         );

--- a/src/components/Pages/Data.js
+++ b/src/components/Pages/Data.js
@@ -106,14 +106,14 @@ export default function Data() {
                 <h1>Data</h1> <hr/>
                 <Gutter h={10} />
                 <p>
-                    <i>ChiVes</i> uses harmonized, standardized environmental data at the census tract scale including tree canopy characteristics,
+                    <i translate="no">ChiVes</i> uses harmonized, standardized environmental data at the census tract scale including tree canopy characteristics,
                     surface temperature, logged traffic volume, urban flood susceptibility, social vulnerability, hardship, modeled fine particulate
                     matter estimates, and more in Chicago, IL around 2018 (data ranges from 2010-2018).
                     Read more on our <a href="/About">About</a> page.
                     <br /><br />
 
                     Data is added and updated through a collaborative partnership of researchers, community organizations, and civic groups. Organizations
-                    and individuals can participate in <i>ChiVes</i> in multiple ways:
+                    and individuals can participate in <i translate="no">ChiVes</i> in multiple ways:
 
                     <br /><br />
                     <li> <a href="https://docs.google.com/forms/d/e/1FAIpQLSdu5zCJcvLXp8eY0p3jLuCWPKSuGHjrw2auO3BsD57ssH4_wA/viewform">Data Collaborative.</a> Integrate
@@ -121,7 +121,7 @@ export default function Data() {
 
 
                     <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSd2gHSB7OKCKEBhB0weIM7ZsRBomVOAl7QhDHOeXu5B7ih_bQ/viewform">Resource Guide.</a> Share your
-                        web-based or print media resource on the Chicago environment. Resources must meet ChiVes standards. </li>
+                        web-based or print media resource on the Chicago environment. Resources must meet<span translate="no"> ChiVes </span>standards. </li>
 
 
                     <li><a href="https://github.com/GeoDaCenter/chicago-environment-explorer">Web Development.</a> Developers and code-enthusiasts can fork the ChiVes
@@ -143,7 +143,7 @@ export default function Data() {
                     <p className="license-description">
                         This data is licensed under a <a href="https://creativecommons.org/licenses/by-nc/2.0/" target='_blank' rel="noopener noreferrer">Creative Commons Attribution Non-Commercial license.</a>
                         <br /><br />
-                        {/* Cite this data as <i>ChiVes Data Contributors</i> */}
+                        {/* Cite this data as <i translate="no">ChiVes Data Contributors</i> */}
                     </p>
                 </Hero>
 

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -383,7 +383,7 @@ export default function Home() {
               <br />
               <br />
               <p>
-                ChiVes is a data collaborative and community mapping application
+               <span translate="no"> ChiVes </span>is a data collaborative and community mapping application
                 that brings data on Chicago’s environment together at the
                 neighborhood level.
                 <br />
@@ -417,7 +417,7 @@ export default function Home() {
             </Grid>
           </Grid>
           <LogoScroll logoList={logoList} />
-          <h2 className="logoScrollText">Thanks to ChiVes Contributors!</h2>
+          <h2 className="logoScrollText">Thanks to<span translate="no"> ChiVes </span>Contributors!</h2>
         </Hero>
       </HomePageContent>
       <Gutter h={60} />

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 body {
   background:#ffffff;
   font-family: 'Roboto', sans-serif;
+  top: 0px !important;
 }
 
 /* div#view-default-view, div#view-MapView {
@@ -153,3 +154,6 @@ button.mapboxgl-ctrl-attrib-button {
   border:1px solid green;
   border-radius:0;
 }
+
+/* Hide Google Analytics Top Bar so it won't overlap with Menu */
+iframe.skiptranslate { visibility: hidden !important; }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 import { Provider } from 'react-redux';
 import './index.css';
@@ -20,7 +21,9 @@ WebFont.load({
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
+		<Router basename={process.env.PUBLIC_URL}>
         <App />
+        </Router>
     </Provider>
   </React.StrictMode>,
   document.getElementById('root')


### PR DESCRIPTION
This PR is for #123. The goal is to add a Google Translation Widget to the Chieve Site.

### How to Test

1. Run `yarn start` to start the app (or try the Netlify URL).
2. You should notice a Google Translation widget floating in the bottom left corner of the page. I set the widget to this location so that it won't overlap with the menu.
![Screenshot 2024-01-22 at 10 46 46 AM](https://github.com/GeoDaCenter/chicago-environment-explorer/assets/92752107/94cb3b6e-4529-4387-950a-51cb3c80d3c2)
3. Choose any language from the list. You should see the page translated.
![Screenshot 2024-01-22 at 10 55 11 AM](https://github.com/GeoDaCenter/chicago-environment-explorer/assets/92752107/017a5d1f-7228-423d-8dac-569e76d34523)
4. Try other pages. You should see your language preference carried across pages.