### PR TITLE
fix: show CUSTOM_INDEX_scaled in Map tooltip, display correct numeric…

### DIFF
--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -233,7 +233,7 @@ const SummaryMapPage = ({ selections }) => {
         'Metadata Doc': null,
         'Original Scale': '0 - 1',
         'Variable Name': 'Custom Index',
-        accessor: (feature) => feature.properties['CUSTOM_INDEX'],
+        accessor: (feature) => feature.properties['CUSTOM_INDEX_scaled'],
         scaling: 1,
         bins: bins,
         colorScale: colorScale,
@@ -297,7 +297,7 @@ const SummaryMapPage = ({ selections }) => {
     return (
         <>
             <div id="mainContainer" style={{ position: 'fixed' }} ref={mapRef}>
-                <MapSection bounds={defaultBounds} showSearch={false} />
+                <MapSection bounds={defaultBounds} showSearch={false} showCustom={true} />
                 <Legend
                     variableName={'Custom Index'}
                     colorScale={colorScale}
@@ -311,7 +311,7 @@ const SummaryMapPage = ({ selections }) => {
                             <p>
                                 {
                                     getUniqueGroupNames()
-                                        .map((group, index, array) => <>
+                                        .map((group, index, array) => <div key={`${group}-${index}`}>
                                         {
                                             index > 0 && array.length > 2 && <>, </>
                                         }
@@ -319,7 +319,7 @@ const SummaryMapPage = ({ selections }) => {
                                             index !== 0 && index === (array.length - 1) && <> and </>
                                         }
                                         <BoldedPinkText>{group}</BoldedPinkText>
-                                    </>)
+                                    </div>)
                                 }.
                                 With an additional focus on {getMaxGroupWeight().name} indicators, the custom index
                                 will be useful for {renderCustomDescription()}.

--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -205,7 +205,7 @@ const LogoContainer = styled.div`
   }
 `;
 
-function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch = true }) {
+function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch = true, showCustom = false }) {
   // fetch pieces of state from store
   const { storedGeojson } = useChivesData();
   const panelState = useSelector((state) => state.panelState);
@@ -224,6 +224,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
 
   const mapRef = useRef(null);
 
+  console.log('rendering map');
   const handlePanMap = (viewState) => {
     mapRef?.current?.flyTo({
       center: [viewState.longitude, viewState.latitude],
@@ -935,7 +936,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
           }}
           ref={hoverRef}
         >
-          <MapTooltipContent content={hoverInfo.object} />
+          <MapTooltipContent content={hoverInfo.object} showCustom={showCustom} />
         </HoverDiv>
       )}
       {!geoids.length && (

--- a/src/components/Map/MapTooltipContent.js
+++ b/src/components/Map/MapTooltipContent.js
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import { Button } from '@mui/material';
 import {colors} from '../../config'
 const PolarSpeciesPlot = React.lazy(() => import('../Charts/PolarSpeciesPlot.js'));
-// This component handles and formats the map tooltip info. 
+// This component handles and formats the map tooltip info.
 // The props passed to this component should contain an object of the hovered object (from deck, info.object by default)
-const MapTooltipContent = ({content}) => {
+const MapTooltipContent = ({content, showCustom = false}) => {
     const {
         geoid,
         acs_population,
@@ -28,12 +28,13 @@ const MapTooltipContent = ({content}) => {
         pct_white,
         percentage_seniors,
         percentage_children,
+        CUSTOM_INDEX_scaled,
     } = content;
     const [speciesPlotInfo, setSpeciesPlotInfo] = useState({
         open: false,
         geoid: null
     });
-    
+
     const handleSpeciesPlot = () => {
         setSpeciesPlotInfo({
             open: true,
@@ -74,6 +75,7 @@ const MapTooltipContent = ({content}) => {
                     <tr><td>Percent Identified as White</td><td>{pct_white && pct_white.toFixed(1)}%</td></tr>
                     <tr><td>Percent Identified as other races</td><td>{pct_other && pct_other.toFixed(1)}%</td></tr>
                     <tr><td>Percent Identified as Hispanic or Latinx</td><td>{pct_hisp && pct_hisp.toFixed(1)}%</td></tr>
+                    {showCustom && <tr><td>Custom Index</td><td>{CUSTOM_INDEX_scaled && CUSTOM_INDEX_scaled.toFixed(3)}</td></tr>}
                 </tbody>
             </table>
             <Button variant="contained" onClick={handleSpeciesPlot} style={{marginTop:'.5em', fontFamily:'"Lato", sans-serif', background:colors.forest}}>Open Species Tree</Button>


### PR DESCRIPTION
## Problem
Numerical data does not match map display

## Approach
* feat: show CUSTOM_INDEX_scaled value in Map tooltip (hidden on `/map` view, but shown on `/builder`)
* fix: use correct `accessor` to visualize correct data on Map

## How to Test
TBD