### PR TITLE
feat: basic responsive layout for index builder

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,7 +63,7 @@ export default function App() {
 				id="google_translate_element"
 				className={classes.googleTranslateElement}
 				style={
-					location.pathname.indexOf("map") > -1 || location.pathname.indexOf("builder") > -1
+					location.pathname.indexOf("map") > -1
 						? { bottom: "4em" } //if on map page, move up to avoid overlapping with map controls
 						: { bottom: "0.5em" }
 				}

--- a/src/components/IndexBuilder/Indicators.js
+++ b/src/components/IndexBuilder/Indicators.js
@@ -5,6 +5,7 @@ import Grid from "@mui/material/Grid";
 import {Divider, ToggleButton} from "@mui/material";
 import {FaInfoCircle} from "@react-icons/all-files/fa/FaInfoCircle";
 import {SLIDER_DEFAULT} from "./Weights";
+import styled from "styled-components";
 
 const css = `
     .MuiGrid-container.MuiGrid-root {
@@ -135,6 +136,17 @@ const IndicatorsSelectableItem = ({ categoryName, selections, variableName, togg
         </Grid>
     </ToggleButton>
 
+const StackedList = styled.div`
+  @media(max-height: 1024px) {
+    overflow-y: auto;
+    max-height: 70vh;
+  }
+  @media(max-height: 400px) {
+    overflow-y: none;
+    max-height: none;
+  }
+`;
+
 /** Renders a list of toggle buttons that allow each variable/indicator to be selected */
 // NOTE: There is no equivalent of getSnapshotBeforeUpdate using React hooks, so we are forced to use a Class component here
 class IndicatorsList extends React.Component {
@@ -186,7 +198,7 @@ class IndicatorsList extends React.Component {
 
     render() {
         return (
-            <div style={{ overflowY: 'auto', maxHeight: '70vh' }} ref={this.listRef}>
+            <StackedList ref={this.listRef}>
                 {Object.keys(variablePresets).filter(variable => {
                     // Only show categories + enabled indicators
                     return variable.includes("HEADER::") || variablePresets[variable].ibEnabled;
@@ -204,7 +216,7 @@ class IndicatorsList extends React.Component {
                                                     toggleSelection={() => this.toggleSelection(variable, variable.listGroup)}>
                         </IndicatorsSelectableItem>
                 ))}
-            </div>
+            </StackedList>
         );
     }
 }

--- a/src/components/IndexBuilder/Indicators.js
+++ b/src/components/IndexBuilder/Indicators.js
@@ -141,7 +141,7 @@ const StackedList = styled.div`
     overflow-y: auto;
     max-height: 70vh;
   }
-  @media(max-height: 400px) {
+  @media(max-height: 900px) {
     overflow-y: none;
     max-height: none;
   }

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -7,7 +7,7 @@ import {FaCaretDown} from "@react-icons/all-files/fa/FaCaretDown";
 import {colors, variablePresets} from "../../config";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import React, {useRef} from "react";
+import React, {useRef, useState} from "react";
 import styled from "styled-components";
 import Button from "@mui/material/Button";
 import {createFileName, useScreenshot} from "use-react-screenshot";
@@ -18,6 +18,7 @@ import {useChivesData} from "../../hooks/useChivesData";
 import {useHistory} from "react-router-dom";
 import JSZip from 'jszip';
 import {readmeText} from "./HelperText";
+import * as SVG from "../../config/svg";
 
 const DEBUG = process.env.REACT_APP_DEBUG?.toLowerCase()?.includes('t');
 
@@ -51,6 +52,184 @@ const PrimaryButton = styled(Button)`
   }
 `;
 
+const VariablePanelContainer = styled.div`
+
+
+  @media (max-height: 1024px) {
+    max-height: 40vw;
+    min-height: 30vw;
+  }
+  @media (max-height: 400px) {
+    max-height: 30vw;
+  }
+  position: fixed;
+  left: 10px;
+  top: 60px;
+  height: auto;
+  min-width: 200px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 2px 0px 5px ${colors.gray}44;
+  border: 1px solid ${colors.green};
+  padding: 0;
+  box-sizing: border-box;
+  transition: 250ms all;
+  font: "Roboto", sans-serif;
+  color: ${colors.black};
+  z-index: 50;
+  // border-radius:20px;
+  &.hidden {
+    transform: translateX(calc(-100% - 20px));
+    @media (max-width: 600px) {
+      transform: translateX(calc(-100% - 30px));
+    }
+  }
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: "Roboto", sans-serif;
+    margin: 0 0 10px 0;
+  }
+  p {
+    font-family: "Lora", serif;
+    margin: 10px 0;
+  }
+  @media (max-width: 1024px) {
+    min-width: 50vw;
+  }
+  @media (max-width: 600px) {
+    width: calc(100% - 6em);
+    top: calc(1em + 45px);
+    height: calc(100% - 6em);
+    left: 0.5em;
+    display: ${(props) => (props.otherPanels ? "none" : "initial")};
+    padding-top: 2em;
+  }
+  button#showHideLeft {
+    position: absolute;
+    left: 95%;
+    top: 20px;
+    width: 40px;
+    height: 40px;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    background-color: ${colors.white};
+    box-shadow: 2px 0px 5px ${colors.gray}88;
+    outline: none;
+    border: 1px solid ${colors.green};
+    // border-radius:20px;
+    cursor: pointer;
+    transition: 500ms all;
+    svg {
+      width: 20px;
+      height: 20px;
+      margin: 10px 0 0 0;
+      @media (max-width: 600px) {
+        margin: 5px;
+      }
+      fill: ${colors.gray};
+      transform: rotate(0deg);
+      transition: 500ms all;
+      .cls-1 {
+        fill: none;
+        stroke-width: 6px;
+        stroke: ${colors.gray};
+      }
+    }
+    :after {
+      opacity: 0;
+      font-weight: bold;
+      content: "Variables";
+      color: ${colors.gray};
+      position: relative;
+      right: -50px;
+      top: -22px;
+      transition: 500ms all;
+      z-index: 4;
+    }
+    @media (max-width: 768px) {
+      top: 120px;
+    }
+    @media (max-width: 600px) {
+      left: calc(100% - 3em);
+      width: 3em;
+      height: 3em;
+      top: 0;
+      :after {
+        display: none;
+      }
+    }
+  }
+  user-select: none;
+`;
+
+const ShowHideButton = styled.button`
+  left: calc(100% + 20px);
+  @media (max-width: 600px) {
+    left: calc(100% + 2.5em);
+  }
+  height: 2rem;
+  width: 2rem;
+  svg {
+    transform: rotate(0deg);
+  }
+  :after {
+    opacity: 1;
+  }
+`
+
+const ControlsContainer = styled.div`
+  max-height: 60vh;
+  overflow-y: scroll;
+  padding: 20px;
+
+  @media (max-height: 899px) {
+    padding: 20px 20px 10vh 20px;
+  }
+
+  @media (max-width: 600px) {
+    width: 100%;
+    max-height: 100%;
+    padding: 0 10px 25vh 10px;
+  }
+  p.data-description {
+    max-width: 40ch;
+    line-height: 1.3;
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  /* Track */
+  ::-webkit-scrollbar-track {
+    background: ${colors.white};
+  }
+
+  /* Handle */
+  ::-webkit-scrollbar-thumb {
+    background: url("${process.env.PUBLIC_URL}/icons/grip.png"),
+      ${colors.gray}55;
+    background-position: center center;
+    background-repeat: no-repeat, no-repeat;
+    background-size: 50%, 100%;
+    transition: 125ms all;
+  }
+
+  /* Handle on hover */
+  ::-webkit-scrollbar-thumb:hover {
+    background: url("${process.env.PUBLIC_URL}/icons/grip.png"),
+      ${colors.darkgray}99;
+    background-position: center center;
+    background-repeat: no-repeat, no-repeat;
+    background-size: 50%, 100%;
+  }
+`
+
 // TODO: source these icons from @react-icons/all-files
 const FaCsvIcon = () =>
     <svg style={{ width: '1rem', marginRight: '1rem' }} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
@@ -76,6 +255,7 @@ const SummaryMapPage = ({ selections }) => {
     const dispatch = useDispatch();
     const { storedGeojson } = useChivesData();
 
+    const [showPanel, setShowPanel] = useState(false);
     const mapParams = useSelector((state) => state.mapParams);
     const colorScale = [[242,240,247],[218,218,235],[188,189,220],[158,154,200],[117,107,177],[84,39,143]];
 
@@ -275,6 +455,7 @@ const SummaryMapPage = ({ selections }) => {
             .filter((value, index, array) => array.indexOf(value) === index);
     }
 
+    // TODO: currently unused
     const getMaxGroupWeight = () => {
         const groupWeights = [];
         selections.map(sel => ({ name: sel.name, group: variablePresets[sel.name].listGroup, value: sel.value }))
@@ -297,7 +478,8 @@ const SummaryMapPage = ({ selections }) => {
             }, undefined);
     }
 
-    // TODO: what do we do about ties??
+    // TODO: tie-breaking behavior?
+    // TODO: currently unused
     const renderCustomDescription = () => {
         const maxWeightGroup = getMaxGroupWeight();
         switch(maxWeightGroup.name) {
@@ -316,6 +498,10 @@ const SummaryMapPage = ({ selections }) => {
         }
     }
 
+    const handleOpenClose = () => {
+        setShowPanel(!showPanel);
+    };
+
     return (
         <>
             <div id="mainContainer" style={{ position: 'fixed' }} ref={mapRef}>
@@ -325,7 +511,17 @@ const SummaryMapPage = ({ selections }) => {
                     colorScale={colorScale}
                     bins={legend}
                 />
-                <FloatingPanel style={{ top: '110px', left: '20px', minHeight: '30rem', maxHeight: '40rem' }}>
+                <ShowHideButton
+                    onClick={handleOpenClose}
+                    id="showHideLeft"
+                    style={{ top: '100vh', position: 'sticky', zIndex: '9999' }}
+                    className={showPanel ? "active" : "hidden"}
+                >
+                    {SVG.info}
+                </ShowHideButton>
+                <VariablePanelContainer
+                    className={showPanel ? "" : "hidden"}
+                    style={{ top: '110px', left: '20px', maxHeight: '40vh', overflowY: 'auto' }}>
                     <div style={{ padding: '0 2rem', marginTop: '2rem' }}>
                         <Typography variant={'h6'} style={{ marginBottom: '1rem' }}>Custom Index</Typography>
                         <Typography variant={'body2'} style={{ marginBottom: '2rem' }}>
@@ -363,7 +559,7 @@ const SummaryMapPage = ({ selections }) => {
                                          height={400} />
                     </div>
 
-                    <div style={{ padding: '0.5rem', width: '100%', backgroundColor: 'lightgrey', position: 'absolute', bottom: 0, }}>
+                    <ControlsContainer style={{ padding: '0.5rem', width: '100%', backgroundColor: 'lightgrey', position: 'sticky', bottom: 0, }}>
                         <Grid container spacing={0}>
                             <Grid item xs>
                                 <LinkButton style={{ fontWeight: 700 }} size={'small'} onClick={() => history.goBack()}>Exit</LinkButton>
@@ -398,8 +594,8 @@ const SummaryMapPage = ({ selections }) => {
                                 </Menu>
                             </Grid>
                         </Grid>
-                    </div>
-                </FloatingPanel>
+                    </ControlsContainer>
+                </VariablePanelContainer>
             </div>
         </>
     );

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -53,14 +53,12 @@ const PrimaryButton = styled(Button)`
 `;
 
 const VariablePanelContainer = styled.div`
-
-
   @media (max-height: 1024px) {
-    max-height: 40vw;
-    min-height: 30vw;
+    max-height: 60vh;
+    min-height: 30vh;
   }
   @media (max-height: 400px) {
-    max-height: 30vw;
+    max-height: 30vh;
   }
   position: fixed;
   left: 10px;
@@ -97,11 +95,7 @@ const VariablePanelContainer = styled.div`
     font-family: "Lora", serif;
     margin: 10px 0;
   }
-  @media (max-width: 1024px) {
-    min-width: 50vw;
-  }
   @media (max-width: 600px) {
-    width: calc(100% - 6em);
     top: calc(1em + 45px);
     height: calc(100% - 6em);
     left: 0.5em;
@@ -180,7 +174,7 @@ const ShowHideButton = styled.button`
   :after {
     opacity: 1;
   }
-`
+`;
 
 const ControlsContainer = styled.div`
   max-height: 60vh;
@@ -521,7 +515,7 @@ const SummaryMapPage = ({ selections }) => {
                 </ShowHideButton>
                 <VariablePanelContainer
                     className={showPanel ? "" : "hidden"}
-                    style={{ top: '110px', left: '20px', maxHeight: '40vh', overflowY: 'auto' }}>
+                    style={{ top: '110px', left: '20px', width: '375px', overflowY: 'auto' }}>
                     <div style={{ padding: '0 2rem', marginTop: '2rem' }}>
                         <Typography variant={'h6'} style={{ marginBottom: '1rem' }}>Custom Index</Typography>
                         <Typography variant={'body2'} style={{ marginBottom: '2rem' }}>

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -165,12 +165,6 @@ const VariablePanelContainer = styled.div`
   user-select: none;
 `;
 
-const SummaryMenuFooterBar = styled(Grid)`
-  @media (max-height: 500px) {
-    display: none;
-  }
-`;
-
 const ControlsContainer = styled.div`
   max-height: 60vh;
   //overflow-y: scroll;
@@ -180,7 +174,7 @@ const ControlsContainer = styled.div`
     padding: 20px 20px 10vh 20px;
   }
   
-  @media (max-height: 500px) {
+  @media (max-width: 600px) {
     display: none;
   }
 

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -165,6 +165,12 @@ const VariablePanelContainer = styled.div`
   user-select: none;
 `;
 
+const SummaryMenuFooterBar = styled(Grid)`
+  @media (max-height: 500px) {
+    display: none;
+  }
+`;
+
 const ControlsContainer = styled.div`
   max-height: 60vh;
   //overflow-y: scroll;
@@ -172,6 +178,10 @@ const ControlsContainer = styled.div`
 
   @media (max-height: 899px) {
     padding: 20px 20px 10vh 20px;
+  }
+  
+  @media (max-height: 500px) {
+    display: none;
   }
 
   @media (max-width: 600px) {

--- a/src/components/IndexBuilder/SummaryAndMap.js
+++ b/src/components/IndexBuilder/SummaryAndMap.js
@@ -54,7 +54,7 @@ const PrimaryButton = styled(Button)`
 
 const VariablePanelContainer = styled.div`
   @media (max-height: 1024px) {
-    max-height: 60vh;
+    max-height: 70vh;
     min-height: 30vh;
   }
   @media (max-height: 400px) {
@@ -101,6 +101,10 @@ const VariablePanelContainer = styled.div`
     left: 0.5em;
     display: ${(props) => (props.otherPanels ? "none" : "initial")};
     padding-top: 2em;
+  }
+  button#showHideLeft.hidden {
+    left: calc(100% + 20px);
+    z-index: 9999;
   }
   button#showHideLeft {
     position: absolute;
@@ -161,24 +165,9 @@ const VariablePanelContainer = styled.div`
   user-select: none;
 `;
 
-const ShowHideButton = styled.button`
-  left: calc(100% + 20px);
-  @media (max-width: 600px) {
-    left: calc(100% + 2.5em);
-  }
-  height: 2rem;
-  width: 2rem;
-  svg {
-    transform: rotate(0deg);
-  }
-  :after {
-    opacity: 1;
-  }
-`;
-
 const ControlsContainer = styled.div`
   max-height: 60vh;
-  overflow-y: scroll;
+  //overflow-y: scroll;
   padding: 20px;
 
   @media (max-height: 899px) {
@@ -505,20 +494,12 @@ const SummaryMapPage = ({ selections }) => {
                     colorScale={colorScale}
                     bins={legend}
                 />
-                <ShowHideButton
-                    onClick={handleOpenClose}
-                    id="showHideLeft"
-                    style={{ top: '100vh', position: 'sticky', zIndex: '9999' }}
-                    className={showPanel ? "active" : "hidden"}
-                >
-                    {SVG.info}
-                </ShowHideButton>
                 <VariablePanelContainer
                     className={showPanel ? "" : "hidden"}
-                    style={{ top: '110px', left: '20px', width: '375px', overflowY: 'auto' }}>
+                    style={{ top: '110px', left: '20px', width: '375px' }}>
                     <div style={{ padding: '0 2rem', marginTop: '2rem' }}>
                         <Typography variant={'h6'} style={{ marginBottom: '1rem' }}>Custom Index</Typography>
-                        <Typography variant={'body2'} style={{ marginBottom: '2rem' }}>
+                        <Typography variant={'body2'}>
                             <p>The custom index you created has theme{getUniqueGroupNames().length > 1 && <>s</>}:</p>
                             <p>
                                 {
@@ -543,7 +524,7 @@ const SummaryMapPage = ({ selections }) => {
 
                         </Typography>
                     </div>
-                    <div style={{ marginBottom:'2rem', padding: '0 2rem 1rem 2rem' }}>
+                    <div style={{ padding: '0 2rem 1rem 2rem' }}>
                         <WeightsPieChart selections={selections}
                                          showLegend={true}
                                          cx={150}
@@ -589,6 +570,13 @@ const SummaryMapPage = ({ selections }) => {
                             </Grid>
                         </Grid>
                     </ControlsContainer>
+                    <button
+                        onClick={handleOpenClose}
+                        id="showHideLeft"
+                        className={showPanel ? "active" : "hidden"}
+                    >
+                        {SVG.settings}
+                    </button>
                 </VariablePanelContainer>
             </div>
         </>

--- a/src/components/Pages/IndexBuilder.js
+++ b/src/components/Pages/IndexBuilder.js
@@ -47,7 +47,7 @@ export default function IndexBuilder() {
             { /*<NavBar showMapControls={true} bounds={defaultBounds} />*/ }
 
             <Grid container spacing={2} style={{ marginTop:'4vh', marginBottom:'10vh', paddingLeft: '15vw', paddingRight: '15vw' }}>
-                <Grid item xs={6}>
+                <Grid item xs={12} lg={6}>
                     {
                         currentStep === 'indicators' && !selectedDetails && <>
                             <HeaderText>
@@ -71,7 +71,7 @@ export default function IndexBuilder() {
                                 <FaArrowCircleLeft onClick={() => setCurrentStep('indicators')} style={{ verticalAlign: 'middle', marginRight: '1rem', color: colors.forest, cursor: 'pointer' }} />
                                 2. Choose Weights
                             </HeaderText>
-                            <div style={{ paddingLeft: '3rem' }}>
+                            <div style={{ paddingLeft: '3rem', marginBottom: '4rem' }}>
                                 <WeightsHelperText />
                             </div>
                         </>
@@ -83,7 +83,7 @@ export default function IndexBuilder() {
                         </>
                     }
                 </Grid>
-                <Grid item xs={6} style={{ paddingTop: '8vh' }}>
+                <Grid item xs={12} lg={6} style={{ paddingTop: '8vh', marginBottom: '10rem' }}>
                     {
                         currentStep === 'indicators' && <>
                             <IndicatorsList selections={selections}

--- a/src/components/Pages/IndexBuilder.js
+++ b/src/components/Pages/IndexBuilder.js
@@ -42,6 +42,10 @@ export default function IndexBuilder() {
     // TODO: Default selections?
     const [selections, setSelections] = useState([]);
 
+    if (currentStep === "summary") {
+        document.getElementById('google_translate_element').style['display'] = "none";
+    }
+
     return (
         <>
             { /*<NavBar showMapControls={true} bounds={defaultBounds} />*/ }


### PR DESCRIPTION
## Problem
Smaller screens have overlapping elements

We would like a more responsive layout that adjusts to the size of the user's screen

Starts to fix #150 

## Approach
* Stacked layout for "Select Indicators" and "Choose Weights" pages
* Adjust panel min/max height on "Summary & Map" page (layout likely needs work)
* fix: avoid double-scroll when IndicatorsList is stacked (on smaller screens)

## How to Test
1. Navigate to https://deploy-preview-156--chicago-env-explorer.netlify.app/builder
    * You should be brought to the "Select Indicators" page
    * For smaller screens, you should see that "Select Indicators" now has a stacked layout with a single scroll bar
2. Select one or more indicators and click Next
    * You should be brought to the "Choose Weights" page
    * For smaller screens, you should see that "Choose Weights" now has a stacked layout with a single scroll bar
3. Adjust weights as desired and click Next
    * You should be brought to the "Summary & Map" page
    * For smaller screens, you should see that "Summary & Map" left-side panel is hidden by default (click the info icon to show the panel). The panel height should also change based on the size of the user's screen.