### PR TITLE
feat: change Default Variable to "Heat Index (Maximum)"

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@ import rawVariables from './variables.json';
 import rawCategories from './categories.json';
 
 export const defaultData = 'chives-data.geojson';
-export const defaultVariable = "Surface Temperature";
+export const defaultVariable = "Heat Index (Maximum)";
 
 // No further processing needed
 export const variableCategories = rawCategories;


### PR DESCRIPTION
## Problem
We would like the Default Variable on the map view to be "Heat Index (Maximum)"

Fixes #155 

## Approach
* feat: change Default Variable to "Heat Index (Maximum)"

## How to Test
1. Navigate to https://deploy-preview-157--chicago-env-explorer.netlify.app/map
    * You should see that "Heat Index (Maximum)" is now selected by default