### PR TITLE
fix: call more attention to Search box for forward geocoding

### DIFF
--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -917,7 +917,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
         <GeocoderContainer>
           <Geocoder
             id="Geocoder"
-            placeholder={"Search by location"}
+            placeholder={"Search for address..."}
             API_KEY={MAPBOX_ACCESS_TOKEN}
             onChange={handleGeocoder}
             height={45}


### PR DESCRIPTION
## Problem
It is easy to overlook the "Search" feature on the map which provides forward geocoding

Fixes #154 

## Approach
fix: adjust placeholder text from "Search by location..." to "Search for address..."

![Screenshot 2024-05-29 at 5 49 21 PM](https://github.com/GeoDaCenter/chicago-environment-explorer/assets/1413653/0854a8bc-c03f-4261-adf9-30cc160ce3d2)

## How to Test
1. Navigate to https://deploy-preview-161--chicago-env-explorer.netlify.app/map
    * You should see the Search box above the Variable Panel (on the left side)
    * You should see the updated placeholder text letting users know what to search for